### PR TITLE
KnowCode: setWp: Fix println is not available at the device

### DIFF
--- a/src/main/java/com/totalcross/knowcode/parse/NodeSax.java
+++ b/src/main/java/com/totalcross/knowcode/parse/NodeSax.java
@@ -944,7 +944,6 @@ public class NodeSax {
 
         }
         wp =  Settings.screenWidth/ wp ;
-        System.out.println(wp);
     }
     /** set parameter height to try to resize a predefined screen size
      * */


### PR DESCRIPTION
This patch removes what appears to be a debug println in setWp that
when you try to compile the project on Linux you have the following error:

```
################################# FATAL ERROR ##################################
Class: com/totalcross/knowcode/parse/NodeSax
Method: setWp
tc.tools.converter.bb.InvalidClassException: Method java/io/PrintStream.println(double) is not available at the device! To find the available ones, see the Javadocs for totalcross.io.PrintStream class.
	at tc.tools.converter.tclass.TCMethod.checkIfAllowed(TCMethod.java:314)
	at tc.tools.converter.tclass.TCMethod.checkMethodInvocations(TCMethod.java:216)
	at tc.tools.converter.tclass.TCMethod.write(TCMethod.java:129)
	at tc.tools.converter.tclass.TCClass.write(TCClass.java:121)
	at tc.tools.converter.J2TC.<init>(J2TC.java:119)
	at tc.tools.converter.J2TC.processFiles(J2TC.java:933)
	at tc.tools.converter.J2TC.process(J2TC.java:1317)
	at tc.Deploy.<init>(Deploy.java:79)
	at tc.Deploy.main(Deploy.java:38)
```

Signed-off-by: Matheus Castello <matheus@castello.eng.br>