### PR TITLE
NodeSax: Fix getStyle

### DIFF
--- a/src/main/java/com/totalcross/knowcode/parse/NodeSax.java
+++ b/src/main/java/com/totalcross/knowcode/parse/NodeSax.java
@@ -80,11 +80,18 @@ public class NodeSax {
     /** Get attribute value of tag <code>"android:textStyle"</code>
      * @return attribute value of tag
      * */
-    public String getStyle() {
+    public String getTextStyle() {
         if (getValue("android:textStyle") == null) {
             return "normal";
         }
         return getValue("android:textStyle");
+    }
+
+    /** Get attribute value of tag <code>"style"</code>
+     * @return attribute value of tag
+     * */
+    public String getStyle() {
+        return getValue("style");
     }
 
     /** Get attribute value of tag <code>"android:id"</code>


### PR DESCRIPTION
getStyle was being used to detect a progressbar was a horizontal or
spinner. But instead of checking the value of the "style" attribute,
the code was checking the attribute for "android:textStyle" which
resulted in all progressbar being parsed as spinners (unless someone
crazy put their text style as "horizontal" 🤪)

Signed-off-by: Matheus Castello <matheus@castello.eng.br>