### PR TITLE
xml reader: changes xml reader to use char to adhere the latest change

### DIFF
--- a/src/main/java/com/totalcross/knowcode/parse/XmlContainerFactory.java
+++ b/src/main/java/com/totalcross/knowcode/parse/XmlContainerFactory.java
@@ -139,8 +139,9 @@ public class XmlContainerFactory {
 
 		if (xml != null) {
 			xml = new String(xml, 0, xml.length, "UTF-8").getBytes("ISO-8859-1");
+			char[] temporaryXml = new String(xml, 0, xml.length, "UTF-8").toCharArray();
 			try {
-				rdr.parse(xml, 0, xml.length);
+				rdr.parse(temporaryXml, 0, temporaryXml.length);
 			} catch (SyntaxException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();

--- a/src/main/java/com/totalcross/knowcode/parse/XmlContainerLayout.java
+++ b/src/main/java/com/totalcross/knowcode/parse/XmlContainerLayout.java
@@ -333,9 +333,9 @@ public abstract class XmlContainerLayout extends Container {
 		byte[] xml = Vm.getFile(getPathXml());
 
 		if (xml != null) {
-			xml = new String(xml, 0, xml.length, "UTF-8").getBytes("ISO-8859-1");
+			char[] temporaryXml = new String(xml, 0, xml.length, "UTF-8").toCharArray();
 			try {
-				rdr.parse(xml, 0, xml.length);
+				rdr.parse(temporaryXml, 0, temporaryXml.length);
 			} catch (SyntaxException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();


### PR DESCRIPTION
A change was made with TotalCross' XMLTokenizer and now it uses char[] instead of byte[], this fixes the compiling error caused by that.